### PR TITLE
에디터 관련 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-organizational-chart": "^2.2.1",
     "react-pdf": "^9.1.0",
     "react-quill": "^2.0.0",
+    "react-quill-new": "^3.2.2",
     "react-router-dom": "^6.16.0",
     "react-use": "^17.4.0",
     "rehype-highlight": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       react-quill:
         specifier: ^2.0.0
         version: 2.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-quill-new:
+        specifier: ^3.2.2
+        version: 3.2.2(quill-delta@5.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-router-dom:
         specifier: ^6.16.0
         version: 6.24.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -3298,6 +3301,12 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+
   lodash.isfunction@3.0.9:
     resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
 
@@ -3894,6 +3903,9 @@ packages:
   parchment@1.1.4:
     resolution: {integrity: sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==}
 
+  parchment@3.0.0:
+    resolution: {integrity: sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4278,8 +4290,16 @@ packages:
     resolution: {integrity: sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==}
     engines: {node: '>=0.10'}
 
+  quill-delta@5.1.0:
+    resolution: {integrity: sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==}
+    engines: {node: '>= 12.0.0'}
+
   quill@1.3.7:
     resolution: {integrity: sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==}
+
+  quill@2.0.2:
+    resolution: {integrity: sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==}
+    engines: {npm: '>=8.2.3'}
 
   raf-schd@4.0.3:
     resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
@@ -4595,6 +4615,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-quill-new@3.2.2:
+    resolution: {integrity: sha512-pWMfSVAG/ErEh8qjffEp7g8FxRZOcYgTjyi0lp5aLRc/8Ii6u9u95NWu4oeDhFJuZ0NX/h1VnOul8WWKvsl0uQ==}
+    peerDependencies:
+      quill-delta: ^5.1.0
+      react: ^16 || ^17 || ^18 || ^19
+      react-dom: ^16 || ^17 || ^18 || ^19
 
   react-quill@2.0.0:
     resolution: {integrity: sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==}
@@ -9206,6 +9233,10 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.clonedeep@4.5.0: {}
+
+  lodash.isequal@4.5.0: {}
+
   lodash.isfunction@3.0.9: {}
 
   lodash.isplainobject@4.0.6: {}
@@ -10029,6 +10060,8 @@ snapshots:
 
   parchment@1.1.4: {}
 
+  parchment@3.0.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -10332,6 +10365,12 @@ snapshots:
       extend: 3.0.2
       fast-diff: 1.1.2
 
+  quill-delta@5.1.0:
+    dependencies:
+      fast-diff: 1.3.0
+      lodash.clonedeep: 4.5.0
+      lodash.isequal: 4.5.0
+
   quill@1.3.7:
     dependencies:
       clone: 2.1.2
@@ -10340,6 +10379,13 @@ snapshots:
       extend: 3.0.2
       parchment: 1.1.4
       quill-delta: 3.6.3
+
+  quill@2.0.2:
+    dependencies:
+      eventemitter3: 5.0.1
+      lodash-es: 4.17.21
+      parchment: 3.0.0
+      quill-delta: 5.1.0
 
   raf-schd@4.0.3: {}
 
@@ -10773,6 +10819,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  react-quill-new@3.2.2(quill-delta@5.1.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      lodash-es: 4.17.21
+      quill: 2.0.2
+      quill-delta: 5.1.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   react-quill@2.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -1,40 +1,27 @@
 /* eslint-disable import/order */
 import '@/utils/highlight';
-import ReactQuill, { ReactQuillProps } from 'react-quill';
-import Toolbar, { formats } from './toolbar';
+import ReactQuill, { ReactQuillProps } from 'react-quill-new';
 import { useSettings } from '@/store/settingStore';
 import { useThemeToken } from '@/theme/hooks';
 import { StyledEditor } from './styles';
 
-interface Props extends ReactQuillProps {
-  sample?: boolean;
-}
-export default function Editor({ id = 'slash-quill', sample = false, ...other }: Props) {
+export default function Editor({ ...other }: ReactQuillProps) {
   const token = useThemeToken();
   const { themeMode } = useSettings();
+
   const modules = {
     toolbar: {
-      container: `#${id}`,
-    },
-    history: {
-      delay: 500,
-      maxStack: 100,
-      userOnly: true,
-    },
-    syntax: true,
-    clipboard: {
-      matchVisual: false,
+      container: [
+        [{ header: [1, 2, 3, 4] }],
+        [{ list: 'ordered' }, { list: 'bullet' }],
+        ['bold', 'italic', 'underline', 'strike'],
+      ],
     },
   };
+
   return (
     <StyledEditor $token={token} $thememode={themeMode}>
-      <Toolbar id={id} isSimple={sample} />
-      <ReactQuill
-        modules={modules}
-        formats={formats}
-        {...other}
-        placeholder="새 글을 작성하세요..."
-      />
+      <ReactQuill {...other} modules={modules} placeholder="새 글을 작성하세요..." />
     </StyledEditor>
   );
 }

--- a/src/components/editor/toolbar.tsx
+++ b/src/components/editor/toolbar.tsx
@@ -89,19 +89,7 @@ export default function Toolbar({ id, isSimple, ...other }: EditorToolbarProps) 
         )}
 
         <div className="ql-formats">
-          <button type="button" className="ql-direction" value="rtl" />
-          <select className="ql-align" />
-        </div>
-
-        <div className="ql-formats">
-          <button type="button" className="ql-link" />
           <button type="button" className="ql-image" />
-          <button type="button" className="ql-video" />
-        </div>
-
-        <div className="ql-formats">
-          {!isSimple && <button type="button" className="ql-formula" />}
-          <button type="button" className="ql-clean" />
         </div>
       </div>
     </StyledToolbar>

--- a/src/components/upload-content/index.tsx
+++ b/src/components/upload-content/index.tsx
@@ -4,13 +4,14 @@ import { useState } from 'react';
 import Editor from '../editor';
 
 function UploadContent({ title }: { title: string }) {
-  const [quillSimple, setQuillSimple] = useState('');
+  const [editorValue, setEditorValue] = useState('');
+
   return (
     <div className="flex flex-col space-y-5 pt-10">
       <h1 className="mb-5 text-2xl font-bold">{title}</h1>
       <div className="flex flex-col space-y-5">
         <Input placeholder="제목을 입력해주세요." />
-        <Editor sample value={quillSimple} onChange={setQuillSimple} />
+        <Editor sample value={editorValue} onChange={setEditorValue} />
       </div>
       <Button className="mx-auto w-52">작성 완료</Button>
     </div>

--- a/src/components/upload-content/index.tsx
+++ b/src/components/upload-content/index.tsx
@@ -5,15 +5,32 @@ import Editor from '../editor';
 
 function UploadContent({ title }: { title: string }) {
   const [editorValue, setEditorValue] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  const isButtonDisabled = inputValue.trim() === '' || editorValue.trim() === '';
+
+  const handleButtonClick = () => {
+    if (!isButtonDisabled) {
+      // upload api자리
+      console.log('Title:', inputValue);
+      console.log('Content:', editorValue);
+    }
+  };
 
   return (
     <div className="flex flex-col space-y-5 pt-10">
       <h1 className="mb-5 text-2xl font-bold">{title}</h1>
       <div className="flex flex-col space-y-5">
-        <Input placeholder="제목을 입력해주세요." />
-        <Editor sample value={editorValue} onChange={setEditorValue} />
+        <Input
+          placeholder="제목을 입력해주세요."
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+        />
+        <Editor value={editorValue} onChange={setEditorValue} />
       </div>
-      <Button className="mx-auto w-52">작성 완료</Button>
+      <Button className="mx-auto w-52" disabled={isButtonDisabled} onClick={handleButtonClick}>
+        작성 완료
+      </Button>
     </div>
   );
 }

--- a/src/pages/proceeding/proceeding-upload/index.tsx
+++ b/src/pages/proceeding/proceeding-upload/index.tsx
@@ -1,9 +1,9 @@
-import UploadFile from '@/components/upload-file';
+import UploadFileComponent from '@/components/upload-file';
 
 const index = () => {
   return (
     <div>
-      <UploadFile title="회의록 업로드" />
+      <UploadFileComponent title="회의록 업로드" />
     </div>
   );
 };

--- a/src/pages/rule/rule-upload/index.tsx
+++ b/src/pages/rule/rule-upload/index.tsx
@@ -1,9 +1,9 @@
-import UploadFile from '@/components/upload-file';
+import UploadFileComponent from '@/components/upload-file';
 
 const index = () => {
   return (
     <div>
-      <UploadFile title="학칙/회칙 업로드" />
+      <UploadFileComponent title="학칙/회칙 업로드" />
     </div>
   );
 };

--- a/src/pages/transaction/transaction-upload/index.tsx
+++ b/src/pages/transaction/transaction-upload/index.tsx
@@ -1,9 +1,9 @@
-import UploadFile from '@/components/upload-file';
+import UploadFileComponent from '@/components/upload-file';
 
 const index = () => {
   return (
     <div>
-      <UploadFile title="입/출금 내역 업로드" />
+      <UploadFileComponent title="입/출금 내역 업로드" />
     </div>
   );
 };


### PR DESCRIPTION
close #19 
(title, 에디터에 내용 있어야지 버튼 활성화되는 로직 구현)

- ckeditor import 에러나서 또 헤매다가.. 하 그냥 react-quill (원래 있던거) 사용해봄
  - **toolbar 관련 이슈 해결법**
     - react-quill은 toolbar를 모듈로 만들어서 커스텀이 가능한데, 이 커스텀한 toolbar를 사용하는 게 렌더링에서 문제가 되었음. 그래서 모듈을 따로 사용하지 않고 직접 modules라는 변수를 정의해 toolbar 커스텀함
   - **브라우저 경고 (react-quill 라이브러리 자체의 이슈)**
     -  [Deprecation] Listener added for a 'DOMNodeInserted' mutation event. This event type is deprecated, and will be removed from this browser VERY soon. Usage of this event listener will cause performance issues today, and represents a large risk of imminent site breakage. Consider using MutationObserver instead. See https://chromestatus.com/feature/5083947249172480 for more information.  => 브라우저에서 더 이상 사용하지 않는 메서드를 내부적으로 사용하고 있어서 뜸
     - 관련해 이슈를 계속 찾아보니까 어떤 사람이 자기가 포크해서 그 에러 해결해놨다고 그 라이브러리 쓰라고 함. (react-quill-new) https://github.com/VaguelySerious/react-quill
     - 경고 더 이상 안뜸 => 해결 완료

<br/>

### 새로운 문제
(글 목록) bullet이 적용 안되고 숫자만 적용됨

-  << 이게 안되고 1. << 이것만 되는 중

## 해당 레포 pr에 해결법인 것 같은게 올라와져 있어서 그대로 라이브러리 코드 내부적으로 똑같이 수정했으나 해결되지 않음 일단 이 상태로 머지함
     

https://github.com/user-attachments/assets/935e15cb-21a6-48e4-bc22-177c940b4c5f

